### PR TITLE
Make homepage responsive for mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -461,14 +461,21 @@ main {
 
 @media screen and (max-width: 768px) {
   .hero-section {
-    width: 80vw;
-    left: 10vw;
+    width: 90vw;
+    left: 5vw;
     top: 15vh;
-    height: 70vh;
+    height: auto;
+    min-height: 70vh;
   }
 
   .blue-section {
-    width: 80vw;
+    width: 90vw;
+    height: auto;
+    min-height: 70vh;
+  }
+
+  .hero-section-title {
+    font-size: clamp(2.5rem, 12vw, 7rem);
   }
 }
 
@@ -778,4 +785,17 @@ section {
   height: 100vh;
   width: 100vw;
   background: red;
+}
+
+@media screen and (max-width: 768px) {
+  #main__title {
+    font-size: clamp(1.5rem, 8.5vw, 6em);
+    letter-spacing: 0.25em;
+  }
+
+  .beta-notification {
+    height: auto;
+    padding: 0.25rem 1rem 0.5rem;
+    font-size: 0.875em;
+  }
 }


### PR DESCRIPTION
- Scale #main__title font using clamp() and reduce letter-spacing so
  the animated letters don't overflow on narrow screens
- Shrink .hero-section-title from fixed 7rem to a fluid clamp value
- Switch .blue-section and .hero-section to auto height (min-height)
  so content isn't clipped on small viewports
- Widen mobile panels from 80vw to 90vw for better use of screen space
- Allow .beta-notification to grow past 3rem when text wraps on mobile

https://claude.ai/code/session_01D6Mj5YZTorpg8ETz7YPj2R